### PR TITLE
feat(nx-remotecache-s3): add prefix path option

### DIFF
--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -18,6 +18,7 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
 | Secret Key    | Required. S3 secret access key                                                                                          | `NX_CACHE_S3_SECRET_KEY`    | `secretKey`   |
 | Endpoint      | Optional. The fully qualified endpoint of the webservice. This is only required when using a custom (non-AWS) endpoint. | `NX_CACHE_S3_ENDPOINT`      | `endpoint`    |
 | Bucket        | Optional. Specify which bucket should be used for storing the cache.                                                    | `NX_CACHE_S3_BUCKET`        | `bucket`      |
+| Prefix        | Optional. Specify prefix path of target object key.                                                                     | `NX_CACHE_S3_PREFIX`        | `prefix`      |
 | Region        | Optional. The AWS region to which this client will send requests.                                                       | `NX_CACHE_S3_REGION`        | `region`      |
 
 ```json
@@ -31,6 +32,7 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
         "secretKey": "mySecretKey",
         "endpoint": "https://some-endpoint.com",
         "bucket": "name-of-bucket",
+        "prefix": "prefix/",
         "region": "us-west-000"
       }
     }

--- a/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
+++ b/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
@@ -6,6 +6,7 @@ import { Stream } from 'stream';
 const ENV_ACCESS_KEY_ID = 'NX_CACHE_S3_ACCESS_KEY_ID';
 const ENV_SECRET_KEY = 'NX_CACHE_S3_SECRET_KEY';
 const ENV_BUCKET = 'NX_CACHE_S3_BUCKET';
+const ENV_PREFIX = 'NX_CACHE_S3_PREFIX';
 const ENV_ENDPOINT = 'NX_CACHE_S3_ENDPOINT';
 const ENV_REGION = 'NX_CACHE_S3_REGION';
 
@@ -13,6 +14,7 @@ const getEnv = (key: string) => process.env[key];
 
 interface S3Options {
   bucket?: string;
+  prefix?: string;
   endpoint?: string;
   region?: string;
   accessKeyId?: string;
@@ -40,6 +42,8 @@ export default createCustomRunner<S3Options>(async (options) => {
 
   const bucket = getEnv(ENV_BUCKET) ?? options.bucket;
 
+  const prefix = getEnv(ENV_PREFIX) ?? options.prefix ?? '';
+
   return {
     name: 'S3',
     fileExists: async (filename) => {
@@ -47,7 +51,7 @@ export default createCustomRunner<S3Options>(async (options) => {
         const result = await s3Storage.headObject({
           /* eslint-disable @typescript-eslint/naming-convention */
           Bucket: bucket,
-          Key: filename,
+          Key: `${prefix}${filename}`,
           /* eslint-enable @typescript-eslint/naming-convention */
         });
         return !!result;
@@ -63,7 +67,7 @@ export default createCustomRunner<S3Options>(async (options) => {
       const result = await s3Storage.getObject({
         /* eslint-disable @typescript-eslint/naming-convention */
         Bucket: bucket,
-        Key: filename,
+        Key: `${prefix}${filename}`,
         /* eslint-enable @typescript-eslint/naming-convention */
       });
       return getStream.buffer(result.Body as Stream);
@@ -72,7 +76,7 @@ export default createCustomRunner<S3Options>(async (options) => {
       await s3Storage.putObject({
         /* eslint-disable @typescript-eslint/naming-convention */
         Bucket: bucket,
-        Key: filename,
+        Key: `${prefix}${filename}`,
         Body: buffer,
         /* eslint-enable @typescript-eslint/naming-convention */
       }),


### PR DESCRIPTION
hello,

This PR adds options to define object key prefix path to S3 objects. It can be useful if you want to use shared bucket with object prefixes to organize objects with paths.