### PR TITLE
build(nx-remotecache-s3): use buildableProjectDepsInPackageJsonType

### DIFF
--- a/libs/nx-remotecache-s3/package.json
+++ b/libs/nx-remotecache-s3/package.json
@@ -25,10 +25,5 @@
   "bugs": {
     "url": "https://github.com/robinpellegrims/pellegrims/issues?q=is%3Aissue+label%3Ascope%3Anx-remotecache-s3+"
   },
-  "homepage": "https://github.com/robinpellegrims/pellegrims/tree/master/libs/nx-remotecache-s3",
-  "dependencies": {
-    "@aws-sdk/client-s3": "^3.72.0",
-    "nx-remotecache-custom": "^1.1.0",
-    "get-stream": "^6.0.1"
-  }
+  "homepage": "https://github.com/robinpellegrims/pellegrims/tree/master/libs/nx-remotecache-s3"
 }

--- a/workspace.json
+++ b/workspace.json
@@ -105,7 +105,8 @@
             "tsConfig": "libs/nx-remotecache-s3/tsconfig.lib.json",
             "packageJson": "libs/nx-remotecache-s3/package.json",
             "main": "libs/nx-remotecache-s3/src/index.ts",
-            "assets": ["libs/nx-remotecache-s3/*.md"]
+            "assets": ["libs/nx-remotecache-s3/*.md"],
+            "buildableProjectDepsInPackageJsonType": "dependencies"
           }
         },
         "version": {


### PR DESCRIPTION
to automatically add dependencies in package.json