### PR TITLE
feat(nx-remotecache-s3): add custom profile option

### DIFF
--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -18,6 +18,7 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
 | Bucket    | Optional. Specify which bucket should be used for storing the cache.                                                    | `NX_CACHE_S3_BUCKET`        | `bucket`   |
 | Prefix    | Optional. Specify prefix path of target object key.                                                                     | `NX_CACHE_S3_PREFIX`        | `prefix`   |
 | Region    | Optional. The AWS region to which this client will send requests.                                                       | `NX_CACHE_S3_REGION`        | `region`   |
+| Profile   | Optional. The AWS profile to use to authenticate.                                                                       | `ENV_PROFILE`               | `profile`  |
 
 ```json
 {

--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -18,7 +18,7 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
 | Bucket    | Optional. Specify which bucket should be used for storing the cache.                                                    | `NX_CACHE_S3_BUCKET`        | `bucket`   |
 | Prefix    | Optional. Specify prefix path of target object key.                                                                     | `NX_CACHE_S3_PREFIX`        | `prefix`   |
 | Region    | Optional. The AWS region to which this client will send requests.                                                       | `NX_CACHE_S3_REGION`        | `region`   |
-| Profile   | Optional. The AWS profile to use to authenticate.                                                                       | `ENV_PROFILE`               | `profile`  |
+| Profile   | Optional. The AWS profile to use to authenticate.                                                                       | `NX_CACHE_S3_PROFILE`       | `profile`  |
 
 ```json
 {

--- a/libs/nx-remotecache-s3/package.json
+++ b/libs/nx-remotecache-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pellegrims/nx-remotecache-s3",
   "main": "src/index.js",
-  "version": "1.0.7",
+  "version": "1.0.6",
   "description": "Remote caching for @nrwl/nx using S3 storage",
   "scripts": {
     "test": "nx test nx-remotecache-s3"

--- a/libs/nx-remotecache-s3/package.json
+++ b/libs/nx-remotecache-s3/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pellegrims/nx-remotecache-s3",
   "main": "src/index.js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Remote caching for @nrwl/nx using S3 storage",
   "scripts": {
     "test": "nx test nx-remotecache-s3"

--- a/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
+++ b/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
@@ -10,6 +10,7 @@ const ENV_BUCKET = 'NX_CACHE_S3_BUCKET';
 const ENV_PREFIX = 'NX_CACHE_S3_PREFIX';
 const ENV_ENDPOINT = 'NX_CACHE_S3_ENDPOINT';
 const ENV_REGION = 'NX_CACHE_S3_REGION';
+const ENV_PROFILE = 'NX_CACHE_S3_PROFILE';
 
 const getEnv = (key: string) => process.env[key];
 
@@ -18,6 +19,7 @@ interface S3Options {
   prefix?: string;
   endpoint?: string;
   region?: string;
+  profile?: string;
 }
 
 const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
@@ -25,6 +27,7 @@ const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
     initEnv(options);
 
     const provider = defaultProvider({
+      profile: getEnv(ENV_PROFILE),
       roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
     });
 


### PR DESCRIPTION
This PR adds the ability to pass a more specific AWS profile to nx remote cache.

This is useful when nx is run on a CI context where the default AWS_PROFILE variable is already occupied for CI actions (pushing docker images, building infra etc) that are too wide to use for storing and retrieving nx cache.