### PR TITLE
feat(nx-remotecache-s3): add support for options.profile

### DIFF
--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -30,7 +30,8 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
         "endpoint": "https://some-endpoint.com",
         "bucket": "name-of-bucket",
         "prefix": "prefix/",
-        "region": "us-west-000"
+        "region": "us-west-000",
+        "profile": "name-of-aws-profile"
       }
     }
   }

--- a/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
+++ b/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
@@ -27,7 +27,7 @@ const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
     initEnv(options);
 
     const provider = defaultProvider({
-      profile: getEnv(ENV_PROFILE),
+      profile: getEnv(ENV_PROFILE) ?? options.profile,
       roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
     });
 


### PR DESCRIPTION
Fixes a bug where nx.json's `options.profile` is not taken into account for AWS_PROFILE selection.