### PR TITLE
feat(nx-remotecache-s3): update env boolean handling and error handling

### DIFF
--- a/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
+++ b/libs/nx-remotecache-s3/src/lib/nx-remotecache-s3.ts
@@ -39,12 +39,14 @@ const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
       endpoint: getEnv(ENV_ENDPOINT) ?? options.endpoint,
       region: getEnv(ENV_REGION) ?? options.region,
       credentials: provider,
-      forcePathStyle: !!getEnv(ENV_FORCE_PATH_STYLE) ?? options.forcePathStyle,
+      forcePathStyle:
+        getEnv(ENV_FORCE_PATH_STYLE) === 'true' ?? options.forcePathStyle,
     });
 
     const bucket = getEnv(ENV_BUCKET) ?? options.bucket;
     const prefix = getEnv(ENV_PREFIX) ?? options.prefix ?? '';
-    const readOnly = getEnv(ENV_READ_ONLY) ?? options.readOnly ?? false;
+    const readOnly =
+      getEnv(ENV_READ_ONLY) === 'true' ?? options.readOnly ?? false;
 
     return {
       name: 'S3',
@@ -58,7 +60,10 @@ const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
           });
           return !!result;
         } catch (error) {
-          if ((error as Error).name === 'NotFound') {
+          if (
+            (error as Error).name === 'Forbidden' ||
+            (error as Error).name === 'NotFound'
+          ) {
             return false;
           } else {
             throw error;
@@ -76,7 +81,7 @@ const runner: typeof defaultTasksRunner = createCustomRunner<S3Options>(
       },
       storeFile: async (filename, buffer) => {
         if (readOnly) {
-          throw new Error('Read Only cache enabled, skipped upload');
+          throw new Error('ReadOnly');
         }
 
         return await s3Storage.putObject({


### PR DESCRIPTION
Following up on #173 to fix a few issues that were discovered.

- This fixes the handling of boolean values set from env variables. There was a chance that a false value would still be treated as truthy with the existing logic for the `NX_CACHE_S3_FORCE_PATH_STYLE` and `NX_CACHE_S3_READ_ONLY` values.

- This also updates the error handling logic for checking if an object exists. Depending on certain permissions, the error returned for this call is either a `403` OR `404` so the code has been updated to reflect both scenarios. Referenced from the permissions section in this doc: https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html