### PR TITLE
fix(nx-remotecache-s3): generated package.json is pinning all dependency versions

### DIFF
--- a/libs/nx-remotecache-s3/package.json
+++ b/libs/nx-remotecache-s3/package.json
@@ -28,5 +28,13 @@
   "homepage": "https://github.com/robinpellegrims/pellegrims/tree/master/libs/nx-remotecache-s3",
   "peerDependencies": {
     "@nrwl/workspace": ">=9.2.2"
+  },
+  "dependencies": {
+    "nx-remotecache-custom": "^1.1.0",
+    "@aws-sdk/client-s3": "^3.72.0",
+    "@aws-sdk/credential-provider-node": "^3.76.0",
+    "@aws-sdk/client-sts": "^3.76.0",
+    "get-stream": "^6.0.1",
+    "tslib": "^2.0.0"
   }
 }


### PR DESCRIPTION
 Fixes #181