### PR TITLE
feat(nx-remotecache-s3): update envs to custom runner v3 format

### DIFF
--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -12,15 +12,15 @@ This package was built with [nx-remotecache-custom](https://www.npmjs.com/packag
 npm install --save-dev @pellegrims/nx-remotecache-s3
 ```
 
-| Parameter        | Description                                                                                                                                           | Environment Variable / .env    | `nx.json`        |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ---------------- |
-| Endpoint         | Optional. The fully qualified endpoint of the webservice. This is only required when using a custom (non-AWS) endpoint.                               | `NX_CACHE_S3_ENDPOINT`         | `endpoint`       |
-| Bucket           | Optional. Specify which bucket should be used for storing the cache.                                                                                  | `NX_CACHE_S3_BUCKET`           | `bucket`         |
-| Prefix           | Optional. Specify prefix path of target object key.                                                                                                   | `NX_CACHE_S3_PREFIX`           | `prefix`         |
-| Region           | Optional. The AWS region to which this client will send requests.                                                                                     | `NX_CACHE_S3_REGION`           | `region`         |
-| Profile          | Optional. The AWS profile to use to authenticate.                                                                                                     | `NX_CACHE_S3_PROFILE`          | `profile`        |
-| Force Path Style | Optional. Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/` instead of `https://<bucket>.s3.amazonaws.com/` | `NX_CACHE_S3_FORCE_PATH_STYLE` | `forcePathStyle` |
-| Read Only        | Optional. Disable writing cache to the S3 bucket. This may be useful if you only want to write to the cache from a CI but not localhost.              | `NX_CACHE_S3_READ_ONLY`        | `readOnly`       |
+| Parameter        | Description                                                                                                                                           | Environment Variable / .env   | `nx.json`        |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ---------------- |
+| Endpoint         | Optional. The fully qualified endpoint of the webservice. This is only required when using a custom (non-AWS) endpoint.                               | `NXCACHE_S3_ENDPOINT`         | `endpoint`       |
+| Bucket           | Optional. Specify which bucket should be used for storing the cache.                                                                                  | `NXCACHE_S3_BUCKET`           | `bucket`         |
+| Prefix           | Optional. Specify prefix path of target object key.                                                                                                   | `NXCACHE_S3_PREFIX`           | `prefix`         |
+| Region           | Optional. The AWS region to which this client will send requests.                                                                                     | `NXCACHE_S3_REGION`           | `region`         |
+| Profile          | Optional. The AWS profile to use to authenticate.                                                                                                     | `NXCACHE_S3_PROFILE`          | `profile`        |
+| Force Path Style | Optional. Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/` instead of `https://<bucket>.s3.amazonaws.com/` | `NXCACHE_S3_FORCE_PATH_STYLE` | `forcePathStyle` |
+| Read Only        | Optional. Disable writing cache to the S3 bucket. This may be useful if you only want to write to the cache from a CI but not localhost.              | `NXCACHE_S3_READ_ONLY`        | `readOnly`       |
 
 ```json
 {

--- a/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
@@ -77,10 +77,10 @@ describe('buildS3Client', () => {
   });
 
   it('with parameters from ENV variables', async () => {
-    process.env.NX_CACHE_S3_ENDPOINT = envValues.endpoint;
-    process.env.NX_CACHE_S3_REGION = envValues.region;
-    process.env.NX_CACHE_S3_FORCE_PATH_STYLE = envValues.forcePathStyle;
-    process.env.NX_CACHE_S3_PROFILE = envValues.profile;
+    process.env.NXCACHE_S3_ENDPOINT = envValues.endpoint;
+    process.env.NXCACHE_S3_REGION = envValues.region;
+    process.env.NXCACHE_S3_FORCE_PATH_STYLE = envValues.forcePathStyle;
+    process.env.NXCACHE_S3_PROFILE = envValues.profile;
     await setupS3TaskRunner(defaultOptions);
     expectS3Instance({ ...envValues, forcePathStyle: true });
   });

--- a/libs/nx-remotecache-s3/src/lib/s3-client.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.ts
@@ -6,10 +6,10 @@ import { getDefaultRoleAssumerWithWebIdentity } from '@aws-sdk/client-sts';
 import type { S3ClientConfig } from '@aws-sdk/client-s3/dist-types/S3Client';
 import type { DefaultProviderInit } from '@aws-sdk/credential-provider-node/dist-types/defaultProvider';
 
-const ENV_ENDPOINT = 'NX_CACHE_S3_ENDPOINT';
-const ENV_PROFILE = 'NX_CACHE_S3_PROFILE';
-const ENV_FORCE_PATH_STYLE = 'NX_CACHE_S3_FORCE_PATH_STYLE';
-const ENV_REGION = 'NX_CACHE_S3_REGION';
+const ENV_ENDPOINT = 'NXCACHE_S3_ENDPOINT';
+const ENV_PROFILE = 'NXCACHE_S3_PROFILE';
+const ENV_FORCE_PATH_STYLE = 'NXCACHE_S3_FORCE_PATH_STYLE';
+const ENV_REGION = 'NXCACHE_S3_REGION';
 
 export const buildS3Client = (
   options: Pick<S3ClientConfig, 'endpoint' | 'region' | 'forcePathStyle'> &

--- a/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
@@ -162,8 +162,8 @@ describe('setupS3TaskRunner', () => {
             ...defaultOptions,
           }));
         it('with parameters from ENV variables', async () => {
-          process.env.NX_CACHE_S3_BUCKET = envValues.bucket;
-          process.env.NX_CACHE_S3_PREFIX = envValues.prefix;
+          process.env.NXCACHE_S3_BUCKET = envValues.bucket;
+          process.env.NXCACHE_S3_PREFIX = envValues.prefix;
           await headObjectCalledWithParams({
             runnerOptions: defaultOptions,
             ...envValues,
@@ -217,8 +217,8 @@ describe('setupS3TaskRunner', () => {
             ...defaultOptions,
           }));
         it('with parameters from ENV variables', async () => {
-          process.env.NX_CACHE_S3_BUCKET = envValues.bucket;
-          process.env.NX_CACHE_S3_PREFIX = envValues.prefix;
+          process.env.NXCACHE_S3_BUCKET = envValues.bucket;
+          process.env.NXCACHE_S3_PREFIX = envValues.prefix;
           await getObjectCalledWithParams({
             runnerOptions: defaultOptions,
             ...envValues,
@@ -246,8 +246,8 @@ describe('setupS3TaskRunner', () => {
           });
         });
         it('with parameters from ENV variables', async () => {
-          process.env.NX_CACHE_S3_BUCKET = envValues.bucket;
-          process.env.NX_CACHE_S3_PREFIX = envValues.prefix;
+          process.env.NXCACHE_S3_BUCKET = envValues.bucket;
+          process.env.NXCACHE_S3_PREFIX = envValues.prefix;
           await uploadCalledWithParams({
             runnerOptions: defaultOptions,
             ...envValues,
@@ -263,7 +263,7 @@ describe('setupS3TaskRunner', () => {
           expect(runner.storeFile).toThrowError('ReadOnly');
         });
         it('through env variable', async () => {
-          process.env.NX_CACHE_S3_READ_ONLY = 'true';
+          process.env.NXCACHE_S3_READ_ONLY = 'true';
           const runner = await setupS3TaskRunner(emptyOptions);
           expect(runner.storeFile).toThrowError('ReadOnly');
         });

--- a/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.ts
+++ b/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.ts
@@ -6,9 +6,9 @@ import { buildCommonCommandInput, getEnv, isReadOnly } from './util';
 import type { CustomRunnerOptions } from 'nx-remotecache-custom';
 import type { RemoteCacheImplementation } from 'nx-remotecache-custom/types/remote-cache-implementation';
 
-const ENV_BUCKET = 'NX_CACHE_S3_BUCKET';
-const ENV_PREFIX = 'NX_CACHE_S3_PREFIX';
-const ENV_READ_ONLY = 'NX_CACHE_S3_READ_ONLY';
+const ENV_BUCKET = 'NXCACHE_S3_BUCKET';
+const ENV_PREFIX = 'NXCACHE_S3_PREFIX';
+const ENV_READ_ONLY = 'NXCACHE_S3_READ_ONLY';
 
 export interface S3Options {
   bucket?: string;


### PR DESCRIPTION
BREAKING CHANGE: ENV vars now start with `NXCACHE_` instead of `NX_CACHE_`

Split out from previous PR #190 

cc: @robinpellegrims 