### PR TITLE
fix(nx-remotecache-s3): add config for provider call for role assumption

### DIFF
--- a/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
@@ -43,6 +43,7 @@ const expectS3Instance = (params: {
   expect(defaultProvider).toHaveBeenCalledWith({
     profile: params.profile,
     roleAssumerWithWebIdentity: expect.any(Function),
+    roleAssumer: expect.any(Function),
   });
   expect(s3Mock).toHaveBeenCalledTimes(1);
   expect(s3Mock).toHaveBeenCalledWith({

--- a/libs/nx-remotecache-s3/src/lib/s3-client.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.ts
@@ -1,7 +1,10 @@
 import { S3 } from '@aws-sdk/client-s3';
 import { getEnv } from './util';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-import { getDefaultRoleAssumerWithWebIdentity } from '@aws-sdk/client-sts';
+import {
+  getDefaultRoleAssumer,
+  getDefaultRoleAssumerWithWebIdentity,
+} from '@aws-sdk/client-sts';
 
 import type { S3ClientConfig } from '@aws-sdk/client-s3/dist-types/S3Client';
 import type { DefaultProviderInit } from '@aws-sdk/credential-provider-node/dist-types/defaultProvider';
@@ -45,6 +48,7 @@ const getCredentialsProvider = (
     return defaultProvider({
       profile: getEnv(ENV_PROFILE) ?? options.profile,
       roleAssumerWithWebIdentity: getDefaultRoleAssumerWithWebIdentity(),
+      roleAssumer: getDefaultRoleAssumer(),
     });
   }
 };


### PR DESCRIPTION
When your AWS config has a role arn configured like this:

```
[profile developer]
role_arn = arn:aws:iam::<account_number>:role/<aws_role>
region = us-east-2
source_profile = default
```
Using the remote cache runner will result in this error:
`Error: Profile developer requires a role to be assumed, but no role assumption callback was provided.`

This can be remedied by adding the `roleAssumer` config value to `defaultProvider` call.

Adding this value is a no-op for configurations that do not use role assumption.