### PR TITLE
feat: add proxy support for nx-remotecache-s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.launch
 .settings/
 *.sublime-workspace
+*.iml
 
 # IDE - VSCode
 .vscode/*

--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -70,6 +70,14 @@ Hash: d3d2bea71ea0f3004304c5cc88cf91be50b02bb636ebbdfcc927626fd8edf1ae
 
 See [nx-remotecache-custom](https://github.com/NiklasPor/nx-remotecache-custom#advanced-configuration).
 
+### Proxy Configuration
+
+To use a proxy to connect to the S3 bucket, set any of the `http_proxy` `https_proxy` `HTTP_PROXY` or `HTTPS_PROXY` environment variables, with the lowercase version taking precedence. If needed, the proxy can be bypassed by adding the S3 endpoint to the `no_proxy` or `NO_PROXY` environment variables.
+
+If the s3 endpoint has not been configured, the `no_proxy` will be checked against the default s3 endpoint, which is `s3.amazonaws.com`. Adding `.amazonaws.com` to your `no_proxy` will bypass the proxy for calls to s3, but MAY also affect other calls to any `amazonaws.com` service.
+
+To specifically bypass the proxy for ONLY S3 calls, make sure to configure the `endpoint` by specifying it in the options parameters or setting the `NXCACHE_S3_ENDPOINT` environment variable, and adding the same url to the `no_proxy` environment variable.
+
 ## More Custom Runners
 
 See [nx-remotecache-custom](https://github.com/NiklasPor/nx-remotecache-custom#all-custom-runners).

--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -12,15 +12,18 @@ This package was built with [nx-remotecache-custom](https://www.npmjs.com/packag
 npm install --save-dev @pellegrims/nx-remotecache-s3
 ```
 
-| Parameter        | Description                                                                                                                                           | Environment Variable / .env   | `nx.json`        |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ---------------- |
-| Endpoint         | Optional. The fully qualified endpoint of the webservice. This is only required when using a custom (non-AWS) endpoint.                               | `NXCACHE_S3_ENDPOINT`         | `endpoint`       |
-| Bucket           | Optional. Specify which bucket should be used for storing the cache.                                                                                  | `NXCACHE_S3_BUCKET`           | `bucket`         |
-| Prefix           | Optional. Specify prefix path of target object key.                                                                                                   | `NXCACHE_S3_PREFIX`           | `prefix`         |
-| Region           | Optional. The AWS region to which this client will send requests.                                                                                     | `NXCACHE_S3_REGION`           | `region`         |
-| Profile          | Optional. The AWS profile to use to authenticate.                                                                                                     | `NXCACHE_S3_PROFILE`          | `profile`        |
-| Force Path Style | Optional. Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/` instead of `https://<bucket>.s3.amazonaws.com/` | `NXCACHE_S3_FORCE_PATH_STYLE` | `forcePathStyle` |
-| Read Only        | Optional. Disable writing cache to the S3 bucket. This may be useful if you only want to write to the cache from a CI but not localhost.              | `NXCACHE_S3_READ_ONLY`        | `readOnly`       |
+| Parameter        | Description                                                                                                                                           | Environment Variable / .env      | `nx.json`        |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- | ---------------- |
+| Endpoint         | Optional. The fully qualified endpoint of the webservice. This is only required when using a custom (non-AWS) endpoint.                               | `NXCACHE_S3_ENDPOINT`            | `endpoint`       |
+| Bucket           | Optional. Specify which bucket should be used for storing the cache.                                                                                  | `NXCACHE_S3_BUCKET`              | `bucket`         |
+| Prefix           | Optional. Specify prefix path of target object key.                                                                                                   | `NXCACHE_S3_PREFIX`              | `prefix`         |
+| Region           | Optional. The AWS region to which this client will send requests.                                                                                     | `NXCACHE_S3_REGION`              | `region`         |
+| Profile          | Optional. The AWS profile to use to authenticate.                                                                                                     | `NXCACHE_S3_PROFILE`             | `profile`        |
+| Force Path Style | Optional. Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/` instead of `https://<bucket>.s3.amazonaws.com/` | `NXCACHE_S3_FORCE_PATH_STYLE`    | `forcePathStyle` |
+| Read Only        | Optional. Disable writing cache to the S3 bucket. This may be useful if you only want to write to the cache from a CI but not localhost.              | `NXCACHE_S3_READ_ONLY`           | `readOnly`       |
+| Http Proxy       | Optional. Useful when your environment must connect to a proxy to access the internet.                                                                | `http_proxy` \|\| `HTTP_PROXY`   |                  |
+| Https Proxy      | Optional. Useful when your environment must connect to a proxy to access the internet.                                                                | `https_proxy` \|\| `HTTPS_PROXY` |                  |
+| No Proxy         | Optional. Useful when your environment must connect to a proxy to access the internet, but is not needed for connecting to aws.                       | `no_proxy` \|\| `NO_PROXY`       |                  |
 
 ```json
 {
@@ -74,9 +77,16 @@ See [nx-remotecache-custom](https://github.com/NiklasPor/nx-remotecache-custom#a
 
 To use a proxy to connect to the S3 bucket, set any of the `http_proxy` `https_proxy` `HTTP_PROXY` or `HTTPS_PROXY` environment variables, with the lowercase version taking precedence. If needed, the proxy can be bypassed by adding the S3 endpoint to the `no_proxy` or `NO_PROXY` environment variables.
 
-If the s3 endpoint has not been configured, the `no_proxy` will be checked against the default s3 endpoint, which is `s3.amazonaws.com`. Adding `.amazonaws.com` to your `no_proxy` will bypass the proxy for calls to s3, but MAY also affect other calls to any `amazonaws.com` service.
+According to AWS, the `endpoint` and `region` parameters are meant to be mutually exclusive (though that isn't the case 100% of the time). Due to the complexity of creating a specific and valid s3 endpoint, and that there is no API provided by the aws-sdk libraries to generate one, this project handles checking the `no_proxy` for the s3 `endpoint` in the following manner.
 
-To specifically bypass the proxy for ONLY S3 calls, make sure to configure the `endpoint` by specifying it in the options parameters or setting the `NXCACHE_S3_ENDPOINT` environment variable, and adding the same url to the `no_proxy` environment variable.
+If the s3 `endpoint` has been configured, it will be checked against the `no_proxy` and if found, s3 requests will bypass the proxy.
+
+If the s3 `endpoint` has not been configured, it is assumed that the global s3 endpoint `s3.amazonaws.com` is being used, and the `no_proxy` will be checked for that url. Because of this, you could see the following behavior:
+
+- If the s3 client does use the global s3 `endpoint` to make requests and if that url has been added to the `no_proxy`, then those requests will correctly bypass the proxy.
+- If the s3 client does not use the global s3 `endpoint` (which could happen if a region other than us-east-1 is specified), and if that non global s3 `endpoint` has not been added to the `no_proxy`, then requests that should bypass the proxy will in fact NOT bypass the proxy. In this case, it is up to the user to determine which `endpoint` is being used and to add it to the `no_proxy`.
+
+TIP: `no_proxy` is a global env variable. To limit the blast radius of `no_proxy`, include the specific service subdomain in the `no_proxy` entry; e.g. `s3.amazonaws.com` vs `amazonaws.com`.
 
 ## More Custom Runners
 

--- a/libs/nx-remotecache-s3/package.json
+++ b/libs/nx-remotecache-s3/package.json
@@ -38,6 +38,9 @@
     "@aws-sdk/credential-provider-node": "^3.329.0",
     "@aws-sdk/lib-storage": "^3.329.0",
     "@aws-sdk/types": "^3.329.0",
+    "@smithy/node-http-handler": "^2.2.2",
+    "hpagent": "^1.2.0",
+    "matcher": "^4.0.0",
     "nx-remotecache-custom": "^19.0.0",
     "tslib": "^2.3.1"
   }

--- a/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.spec.ts
@@ -1,37 +1,19 @@
 import { setupS3TaskRunner } from './setup-s3-task-runner';
+import { getProxyConfig } from './s3-client';
 import { S3 } from '@aws-sdk/client-s3';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
-
-import type { CustomRunnerOptions } from 'nx-remotecache-custom';
-import type { S3Options } from './setup-s3-task-runner';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import {
+  clearProxyInfo,
+  defaultOptions,
+  emptyOptions,
+  envValues,
+} from './test-utils';
 
 jest.mock('@aws-sdk/client-s3');
 jest.mock('@aws-sdk/credential-provider-node');
 
 const s3Mock = jest.mocked(S3);
-
-const emptyOptions: CustomRunnerOptions<S3Options> = { lifeCycle: {} };
-
-const defaultOptions: CustomRunnerOptions<S3Options> = {
-  lifeCycle: {},
-  endpoint: 'optionsEndpoint',
-  region: 'optionsRegion',
-  forcePathStyle: true,
-  profile: 'optionsProfile',
-  bucket: 'optionsBucket',
-  prefix: 'optionsPrefix',
-  readOnly: false,
-};
-
-const envValues: Record<keyof S3Options, string> = {
-  endpoint: 'envEndpoint',
-  region: 'envRegion',
-  forcePathStyle: 'true',
-  profile: 'envProfile',
-  bucket: 'envBucket',
-  prefix: 'envPrefix',
-  readOnly: 'false',
-};
 
 const expectS3Instance = (params: {
   endpoint?: string;
@@ -57,6 +39,8 @@ const expectS3Instance = (params: {
 describe('buildS3Client', () => {
   const originalEnv = process.env;
 
+  beforeEach(clearProxyInfo);
+
   afterEach(() => {
     process.env = { ...originalEnv };
     jest.clearAllMocks();
@@ -77,12 +61,80 @@ describe('buildS3Client', () => {
     expectS3Instance({ ...defaultOptions });
   });
 
-  it('with parameters from ENV variables', async () => {
+  it('with parameters from ENV variables (no proxy info)', async () => {
     process.env.NXCACHE_S3_ENDPOINT = envValues.endpoint;
     process.env.NXCACHE_S3_REGION = envValues.region;
     process.env.NXCACHE_S3_FORCE_PATH_STYLE = envValues.forcePathStyle;
     process.env.NXCACHE_S3_PROFILE = envValues.profile;
     await setupS3TaskRunner(defaultOptions);
     expectS3Instance({ ...envValues, forcePathStyle: true });
+  });
+
+  it('with parameters from ENV variables (with proxy info)', async () => {
+    process.env.NXCACHE_S3_ENDPOINT = envValues.endpoint;
+    process.env.NXCACHE_S3_REGION = envValues.region;
+    process.env.NXCACHE_S3_FORCE_PATH_STYLE = envValues.forcePathStyle;
+    process.env.NXCACHE_S3_PROFILE = envValues.profile;
+    process.env.HTTP_PROXY = 'http://proxy.domain.com:8888';
+    process.env.HTTPS_PROXY = 'https://proxy.domain.com:8888';
+
+    await setupS3TaskRunner(defaultOptions);
+
+    expect(defaultProvider).toHaveBeenCalledTimes(1);
+    expect(defaultProvider).toHaveBeenCalledWith({
+      profile: envValues.profile,
+      roleAssumer: expect.any(Function),
+      roleAssumerWithWebIdentity: expect.any(Function),
+    });
+    expect(s3Mock).toHaveBeenCalledTimes(1);
+    expect(s3Mock).toHaveBeenCalledWith({
+      endpoint: envValues.endpoint,
+      region: envValues.region,
+      forcePathStyle: true,
+      credentials: jest.mocked(defaultProvider).mock.results[0].value,
+      requestHandler: expect.any(NodeHttpHandler),
+    });
+  });
+});
+
+describe('getProxyConfig', () => {
+  beforeEach(clearProxyInfo);
+
+  it('should not set requestHandler when proxy info is unset', async () => {
+    const proxyConfig = getProxyConfig();
+
+    expect(proxyConfig).toEqual({});
+  });
+
+  it('should not set requestHandler when the endpoint is in the no_proxy list', async () => {
+    process.env.HTTPS_PROXY = 'https://proxy.domain.com:8888';
+    process.env.NO_PROXY = '.aws.com';
+    process.env.NXCACHE_S3_ENDPOINT = 'https://endpoint.aws.com';
+
+    const proxyConfig = getProxyConfig();
+
+    expect(proxyConfig).toEqual({});
+  });
+
+  it('should set requestHandler when httpProxy info is set', async () => {
+    process.env.HTTP_PROXY = 'http://proxy.domain.com:8888';
+    process.env.NXCACHE_S3_ENDPOINT = 'https://endpoint.aws.com';
+
+    const proxyConfig = getProxyConfig();
+
+    expect(proxyConfig).toEqual({
+      requestHandler: expect.any(NodeHttpHandler),
+    });
+  });
+
+  it('should set requestHandler when httpsProxy info is set', async () => {
+    process.env.HTTPS_PROXY = 'https://proxy.domain.com:8888';
+    process.env.NXCACHE_S3_ENDPOINT = 'https://endpoint.aws.com';
+
+    const proxyConfig = getProxyConfig();
+
+    expect(proxyConfig).toEqual({
+      requestHandler: expect.any(NodeHttpHandler),
+    });
   });
 });

--- a/libs/nx-remotecache-s3/src/lib/s3-client.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.ts
@@ -24,7 +24,7 @@ const ENV_FORCE_PATH_STYLE = 'NXCACHE_S3_FORCE_PATH_STYLE';
 const ENV_REGION = 'NXCACHE_S3_REGION';
 const ENV_ACCESS_KEY_ID = 'NXCACHE_S3_ACCESS_KEY_ID';
 const ENV_SECRET_ACCESS_KEY = 'NXCACHE_S3_SECRET_ACCESS_KEY';
-const DEFAULT_S3_ENDPOINT = 'https://amazonaws.com';
+const DEFAULT_S3_ENDPOINT = 'https://s3.amazonaws.com';
 
 function getHttpAgent(): HttpsProxyAgent {
   return new HttpsProxyAgent({ proxy: getHttpProxy() as string });

--- a/libs/nx-remotecache-s3/src/lib/s3-client.ts
+++ b/libs/nx-remotecache-s3/src/lib/s3-client.ts
@@ -1,10 +1,18 @@
 import { S3 } from '@aws-sdk/client-s3';
-import { getEnv } from './util';
+import {
+  getEnv,
+  getHttpProxy,
+  getHttpsProxy,
+  getNoProxy,
+  matchesNoProxy,
+} from './util';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import {
   getDefaultRoleAssumer,
   getDefaultRoleAssumerWithWebIdentity,
 } from '@aws-sdk/client-sts';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+import { HttpsProxyAgent } from 'hpagent';
 
 import type { S3ClientConfig } from '@aws-sdk/client-s3/dist-types/S3Client';
 import type { DefaultProviderInit } from '@aws-sdk/credential-provider-node/dist-types/defaultProvider';
@@ -16,6 +24,25 @@ const ENV_FORCE_PATH_STYLE = 'NXCACHE_S3_FORCE_PATH_STYLE';
 const ENV_REGION = 'NXCACHE_S3_REGION';
 const ENV_ACCESS_KEY_ID = 'NXCACHE_S3_ACCESS_KEY_ID';
 const ENV_SECRET_ACCESS_KEY = 'NXCACHE_S3_SECRET_ACCESS_KEY';
+const DEFAULT_S3_ENDPOINT = 'https://amazonaws.com';
+
+function getHttpAgent(): HttpsProxyAgent {
+  return new HttpsProxyAgent({ proxy: getHttpProxy() as string });
+}
+
+function getHttpsAgent(): HttpsProxyAgent {
+  return new HttpsProxyAgent({ proxy: getHttpsProxy() as string });
+}
+
+export const getProxyConfig = (s3Endpoint: string = DEFAULT_S3_ENDPOINT) => ({
+  ...(!matchesNoProxy(s3Endpoint, getNoProxy()) &&
+    (getHttpProxy() || getHttpsProxy()) && {
+      requestHandler: new NodeHttpHandler({
+        ...(getHttpProxy() && { httpAgent: getHttpAgent() }),
+        ...(getHttpsProxy() && { httpsAgent: getHttpsAgent() }),
+      }),
+    }),
+});
 
 export const buildS3Client = (
   options: Pick<S3ClientConfig, 'endpoint' | 'region' | 'forcePathStyle'> &
@@ -29,6 +56,11 @@ export const buildS3Client = (
     credentials: provider,
     forcePathStyle:
       getEnv(ENV_FORCE_PATH_STYLE) === 'true' || options.forcePathStyle,
+    ...getProxyConfig(
+      getEnv(ENV_ENDPOINT) ??
+        (options.endpoint as string) ??
+        DEFAULT_S3_ENDPOINT
+    ),
   });
 };
 

--- a/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
@@ -2,7 +2,12 @@ import { S3 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { Readable } from 'stream';
 import { setupS3TaskRunner } from './setup-s3-task-runner';
-
+import {
+  clearProxyInfo,
+  defaultOptions,
+  emptyOptions,
+  envValues,
+} from './test-utils';
 import type { CustomRunnerOptions } from 'nx-remotecache-custom';
 import type { S3Options } from './setup-s3-task-runner';
 
@@ -23,29 +28,6 @@ jest.mocked(S3.prototype.getObject).mockImplementation(() =>
 );
 
 jest.mock('@aws-sdk/credential-provider-node');
-
-const emptyOptions: CustomRunnerOptions<S3Options> = { lifeCycle: {} };
-
-const defaultOptions: CustomRunnerOptions<S3Options> = {
-  lifeCycle: {},
-  endpoint: 'optionsEndpoint',
-  region: 'optionsRegion',
-  forcePathStyle: true,
-  profile: 'optionsProfile',
-  bucket: 'optionsBucket',
-  prefix: 'optionsPrefix',
-  readOnly: false,
-};
-
-const envValues: Record<keyof S3Options, string> = {
-  endpoint: 'envEndpoint',
-  region: 'envRegion',
-  forcePathStyle: 'true',
-  profile: 'envProfile',
-  bucket: 'envBucket',
-  prefix: 'envPrefix',
-  readOnly: 'false',
-};
 
 const mockHeadObjectError = (error: string) =>
   jest
@@ -120,6 +102,8 @@ const uploadCalledWithParams = async ({
 
 describe('setupS3TaskRunner', () => {
   const originalEnv = process.env;
+
+  beforeEach(clearProxyInfo);
 
   afterEach(() => {
     process.env = { ...originalEnv };

--- a/libs/nx-remotecache-s3/src/lib/test-utils.ts
+++ b/libs/nx-remotecache-s3/src/lib/test-utils.ts
@@ -1,0 +1,34 @@
+import { CustomRunnerOptions } from 'nx-remotecache-custom';
+import { S3Options } from './setup-s3-task-runner';
+
+export const emptyOptions: CustomRunnerOptions<S3Options> = { lifeCycle: {} };
+
+export const defaultOptions: CustomRunnerOptions<S3Options> = {
+  lifeCycle: {},
+  endpoint: 'optionsEndpoint',
+  region: 'optionsRegion',
+  forcePathStyle: true,
+  profile: 'optionsProfile',
+  bucket: 'optionsBucket',
+  prefix: 'optionsPrefix',
+  readOnly: false,
+};
+
+export const envValues: Record<keyof S3Options, string> = {
+  endpoint: 'envEndpoint',
+  region: 'envRegion',
+  forcePathStyle: 'true',
+  profile: 'envProfile',
+  bucket: 'envBucket',
+  prefix: 'envPrefix',
+  readOnly: 'false',
+};
+
+export const clearProxyInfo = () => {
+  delete process.env.HTTPS_PROXY;
+  delete process.env.https_proxy;
+  delete process.env.HTTP_PROXY;
+  delete process.env.http_proxy;
+  delete process.env.NO_PROXY;
+  delete process.env.no_proxy;
+};

--- a/libs/nx-remotecache-s3/src/lib/util.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/util.spec.ts
@@ -1,8 +1,11 @@
-import type { CustomRunnerOptions } from 'nx-remotecache-custom';
-import type { S3Options } from './setup-s3-task-runner';
-import { buildCommonCommandInput, getEnv, isReadOnly } from './util';
-
-const emptyOptions: CustomRunnerOptions<S3Options> = { lifeCycle: {} };
+import { clearProxyInfo, emptyOptions } from './test-utils';
+import {
+  buildCommonCommandInput,
+  getEnv,
+  isReadOnly,
+  getHttpProxy,
+  getHttpsProxy,
+} from './util';
 
 describe('util', () => {
   const originalEnv = process.env;
@@ -81,6 +84,32 @@ describe('util', () => {
     it('returns false when env is "somestring" and option is undefined', () => {
       process.env.TEST_ENV = 'somestring';
       expect(isReadOnly({ ...emptyOptions }, 'TEST_ENV')).toBe(false);
+    });
+  });
+  describe('get proxy information', () => {
+    beforeEach(clearProxyInfo);
+
+    it('should return undefined when http_proxy and HTTP_PROXY is not set', () => {
+      expect(getHttpProxy()).toBe(undefined);
+    });
+    it('should return imaproxy when http_proxy is set', () => {
+      process.env.http_proxy = 'imaproxy';
+      expect(getHttpProxy()).toBe('imaproxy');
+    });
+    it('should return imaproxy when HTTP_PROXY is set', () => {
+      process.env.HTTP_PROXY = 'imaproxy';
+      expect(getHttpProxy()).toBe('imaproxy');
+    });
+    it('should return undefined when https_proxy and HTTPS_PROXY is not set', () => {
+      expect(getHttpsProxy()).toBe(undefined);
+    });
+    it('should return imaproxy when https_proxy is set', () => {
+      process.env.https_proxy = 'imaproxy';
+      expect(getHttpsProxy()).toBe('imaproxy');
+    });
+    it('should return imaproxy when HTTPS_PROXY is set', () => {
+      process.env.HTTPS_PROXY = 'imaproxy';
+      expect(getHttpsProxy()).toBe('imaproxy');
     });
   });
 });

--- a/libs/nx-remotecache-s3/src/lib/util.ts
+++ b/libs/nx-remotecache-s3/src/lib/util.ts
@@ -1,5 +1,10 @@
 import type { CustomRunnerOptions } from 'nx-remotecache-custom';
 import type { S3Options } from './setup-s3-task-runner';
+import { isMatch } from 'matcher';
+
+const HTTP_PROXY = 'HTTP_PROXY';
+const HTTPS_PROXY = 'HTTPS_PROXY';
+const NO_PROXY = 'NO_PROXY';
 
 export const getEnv = (key: string) => process.env[key];
 
@@ -24,4 +29,56 @@ export const isReadOnly = (
     if (readonly === 'false') return false;
   }
   return options.readOnly ?? false;
+};
+
+export const getHttpProxy = (): string | undefined =>
+  getEnv(HTTP_PROXY.toLowerCase()) || getEnv(HTTP_PROXY) || undefined;
+
+export const getHttpsProxy = (): string | undefined =>
+  getEnv(HTTPS_PROXY.toLowerCase()) || getEnv(HTTPS_PROXY) || undefined;
+
+export const getNoProxy = (): string | undefined =>
+  getEnv(NO_PROXY.toLowerCase()) || getEnv(NO_PROXY) || undefined;
+
+export const matchesNoProxy = (
+  subjectUrl: string,
+  noProxy: string | undefined
+) => {
+  if (!noProxy) return false;
+
+  const subjectUrlTokens = new URL(subjectUrl);
+  const rules = noProxy.split(/[\s,]+/);
+
+  for (const rule of rules) {
+    const ruleMatch = rule
+      .replace(/^(?<leadingDot>\.)/, '*')
+      .match(/^(?<hostname>.+?)(?::(?<port>\d+))?$/);
+
+    if (!ruleMatch || !ruleMatch.groups) {
+      throw new Error('Invalid NO_PROXY pattern.');
+    }
+
+    if (!ruleMatch.groups.hostname) {
+      throw new Error(
+        'NO_PROXY entry pattern must include hostname. Use * to match any hostname.'
+      );
+    }
+
+    const hostnameIsMatch = isMatch(
+      subjectUrlTokens.hostname,
+      ruleMatch.groups.hostname
+    );
+
+    if (
+      hostnameIsMatch &&
+      (!ruleMatch.groups ||
+        !ruleMatch.groups.port ||
+        (subjectUrlTokens.port &&
+          subjectUrlTokens.port === ruleMatch.groups.port))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "@aws-sdk/s3-request-presigner": "^3.473.0",
     "@aws-sdk/types": "^3.468.0",
     "@smithy/abort-controller": "^2.0.15",
+    "@smithy/node-http-handler": "^2.2.2",
     "@swc/helpers": "0.5.3",
+    "hpagent": "^1.2.0",
+    "matcher": "^4.0.0",
     "nx-remotecache-custom": "^19.0.0",
     "semver": "^6.3.1",
     "tslib": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,18 @@ dependencies:
   '@smithy/abort-controller':
     specifier: ^2.0.15
     version: 2.0.15
+  '@smithy/node-http-handler':
+    specifier: ^2.2.2
+    version: 2.2.2
   '@swc/helpers':
     specifier: 0.5.3
     version: 0.5.3
+  hpagent:
+    specifier: ^1.2.0
+    version: 1.2.0
+  matcher:
+    specifier: ^4.0.0
+    version: 4.0.0
   nx-remotecache-custom:
     specifier: ^19.0.0
     version: 19.0.0(nx@19.0.6)
@@ -322,12 +331,12 @@ packages:
       '@smithy/invalid-dependency': 2.0.15
       '@smithy/md5-js': 2.0.17
       '@smithy/middleware-content-length': 2.0.17
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/middleware-retry': 2.0.24
       '@smithy/middleware-serde': 2.0.15
       '@smithy/middleware-stack': 2.0.9
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/node-http-handler': 2.2.1
+      '@smithy/node-http-handler': 2.2.2
       '@smithy/protocol-http': 3.0.11
       '@smithy/smithy-client': 2.1.18
       '@smithy/types': 2.7.0
@@ -372,15 +381,15 @@ packages:
       '@smithy/hash-node': 2.0.17
       '@smithy/invalid-dependency': 2.0.15
       '@smithy/middleware-content-length': 2.0.17
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/middleware-retry': 2.0.24
       '@smithy/middleware-serde': 2.0.15
       '@smithy/middleware-stack': 2.0.9
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/node-http-handler': 2.2.1
+      '@smithy/node-http-handler': 2.2.2
       '@smithy/protocol-http': 3.0.11
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/url-parser': 2.0.15
       '@smithy/util-base64': 2.0.1
       '@smithy/util-body-length-browser': 2.0.1
@@ -422,12 +431,12 @@ packages:
       '@smithy/hash-node': 2.0.17
       '@smithy/invalid-dependency': 2.0.15
       '@smithy/middleware-content-length': 2.0.17
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/middleware-retry': 2.0.24
       '@smithy/middleware-serde': 2.0.15
       '@smithy/middleware-stack': 2.0.9
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/node-http-handler': 2.2.1
+      '@smithy/node-http-handler': 2.2.2
       '@smithy/protocol-http': 3.0.11
       '@smithy/smithy-client': 2.1.18
       '@smithy/types': 2.7.0
@@ -466,7 +475,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/property-provider': 2.0.16
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -485,7 +494,7 @@ packages:
       '@smithy/credential-provider-imds': 2.1.4
       '@smithy/property-provider': 2.0.16
       '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     transitivePeerDependencies:
       - aws-crt
@@ -523,7 +532,7 @@ packages:
       '@aws-sdk/types': 3.468.0
       '@smithy/property-provider': 2.0.16
       '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -539,7 +548,7 @@ packages:
       '@aws-sdk/types': 3.468.0
       '@smithy/property-provider': 2.0.16
       '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     transitivePeerDependencies:
       - aws-crt
@@ -554,7 +563,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/property-provider': 2.0.16
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -569,7 +578,7 @@ packages:
     dependencies:
       '@aws-sdk/client-s3': 3.473.0
       '@smithy/abort-controller': 2.0.15
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/smithy-client': 2.1.18
       buffer: 5.6.0
       events: 3.3.0
@@ -588,7 +597,7 @@ packages:
       '@aws-sdk/util-arn-parser': 3.465.0
       '@smithy/node-config-provider': 2.1.8
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-config-provider': 2.0.0
       tslib: 2.5.0
     dev: false
@@ -602,7 +611,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -618,7 +627,7 @@ packages:
       '@aws-sdk/types': 3.468.0
       '@smithy/is-array-buffer': 2.0.0
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.5.0
     dev: false
@@ -632,7 +641,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -644,7 +653,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -656,7 +665,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -669,7 +678,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -686,7 +695,7 @@ packages:
       '@smithy/protocol-http': 3.0.11
       '@smithy/signature-v4': 2.0.18
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-config-provider': 2.0.0
       tslib: 2.5.0
     dev: false
@@ -700,7 +709,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-signing': 3.468.0
       '@aws-sdk/types': 3.468.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -715,7 +724,7 @@ packages:
       '@smithy/property-provider': 2.0.16
       '@smithy/protocol-http': 3.0.11
       '@smithy/signature-v4': 2.0.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-middleware': 2.0.8
       tslib: 2.5.0
     dev: false
@@ -728,7 +737,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -742,7 +751,7 @@ packages:
       '@aws-sdk/types': 3.468.0
       '@aws-sdk/util-endpoints': 3.470.0
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -754,7 +763,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-config-provider': 2.0.0
       '@smithy/util-middleware': 2.0.8
       tslib: 2.5.0
@@ -770,7 +779,7 @@ packages:
       '@aws-sdk/signature-v4-multi-region': 3.470.0
       '@aws-sdk/types': 3.468.0
       '@aws-sdk/util-format-url': 3.468.0
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/protocol-http': 3.0.11
       '@smithy/smithy-client': 2.1.18
       '@smithy/types': 2.7.0
@@ -788,7 +797,7 @@ packages:
       '@aws-sdk/types': 3.468.0
       '@smithy/protocol-http': 3.0.11
       '@smithy/signature-v4': 2.0.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -815,17 +824,17 @@ packages:
       '@smithy/hash-node': 2.0.17
       '@smithy/invalid-dependency': 2.0.15
       '@smithy/middleware-content-length': 2.0.17
-      '@smithy/middleware-endpoint': 2.2.3
+      '@smithy/middleware-endpoint': 2.4.6
       '@smithy/middleware-retry': 2.0.24
       '@smithy/middleware-serde': 2.0.15
       '@smithy/middleware-stack': 2.0.9
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/node-http-handler': 2.2.1
+      '@smithy/node-http-handler': 2.2.2
       '@smithy/property-provider': 2.0.16
       '@smithy/protocol-http': 3.0.11
       '@smithy/shared-ini-file-loader': 2.2.7
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/url-parser': 2.0.15
       '@smithy/util-base64': 2.0.1
       '@smithy/util-body-length-browser': 2.0.1
@@ -882,7 +891,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/querystring-builder': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -903,7 +912,7 @@ packages:
       }
     dependencies:
       '@aws-sdk/types': 3.468.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       bowser: 2.11.0
       tslib: 2.5.0
     dev: false
@@ -922,7 +931,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.468.0
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -942,7 +951,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5057,6 +5066,17 @@ packages:
       tslib: 2.5.0
     dev: false
 
+  /@smithy/abort-controller@2.1.4:
+    resolution:
+      {
+        integrity: sha512-66HO817oIZ2otLIqy06R5muapqZjkgF1jfU0wyNko8cuqZNu8nbS9ljlhcRYw/M/uWRJzB9ih81DLSHhYbBLlQ==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
   /@smithy/chunked-blob-reader-native@2.0.1:
     resolution:
       {
@@ -5084,7 +5104,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-config-provider': 2.0.0
       '@smithy/util-middleware': 2.0.8
       tslib: 2.5.0
@@ -5099,7 +5119,7 @@ packages:
     dependencies:
       '@smithy/node-config-provider': 2.1.8
       '@smithy/property-provider': 2.0.16
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/url-parser': 2.0.15
       tslib: 2.5.0
     dev: false
@@ -5111,7 +5131,7 @@ packages:
       }
     dependencies:
       '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-hex-encoding': 2.0.0
       tslib: 2.5.0
     dev: false
@@ -5124,7 +5144,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/eventstream-serde-universal': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5135,7 +5155,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5147,7 +5167,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/eventstream-serde-universal': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5159,7 +5179,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/eventstream-codec': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5171,7 +5191,7 @@ packages:
     dependencies:
       '@smithy/protocol-http': 3.0.11
       '@smithy/querystring-builder': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-base64': 2.0.1
       tslib: 2.5.0
     dev: false
@@ -5184,7 +5204,7 @@ packages:
     dependencies:
       '@smithy/chunked-blob-reader': 2.0.0
       '@smithy/chunked-blob-reader-native': 2.0.1
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5195,7 +5215,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.5.0
@@ -5208,7 +5228,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.5.0
     dev: false
@@ -5219,7 +5239,7 @@ packages:
         integrity: sha512-dlEKBFFwVfzA5QroHlBS94NpgYjXhwN/bFfun+7w3rgxNvVy79SK0w05iGc7UAeC5t+D7gBxrzdnD6hreZnDVQ==,
       }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5239,7 +5259,7 @@ packages:
         integrity: sha512-jmISTCnEkOnm2oCNx/rMkvBT/eQh3aA6nktevkzbmn/VYqYEuc5Z2n5sTTqsciMSO01Lvf56wG1A4twDqovYeQ==,
       }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-utf8': 2.0.2
       tslib: 2.5.0
     dev: false
@@ -5252,23 +5272,23 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/protocol-http': 3.0.11
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
-  /@smithy/middleware-endpoint@2.2.3:
+  /@smithy/middleware-endpoint@2.4.6:
     resolution:
       {
-        integrity: sha512-nYfxuq0S/xoAjdLbyn1ixeVB6cyH9wYCMtbbOCpcCRYR5u2mMtqUtVjjPAZ/DIdlK3qe0tpB0Q76szFGNuz+kQ==,
+        integrity: sha512-AsXtUXHPOAS0EGZUSFOsVJvc7p0KL29PGkLxLfycPOcFVLru/oinYB6yvyL73ZZPX2OB8sMYUMrj7eH2kI7V/w==,
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/middleware-serde': 2.0.15
-      '@smithy/node-config-provider': 2.1.8
-      '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
-      '@smithy/url-parser': 2.0.15
-      '@smithy/util-middleware': 2.0.8
+      '@smithy/middleware-serde': 2.2.1
+      '@smithy/node-config-provider': 2.2.5
+      '@smithy/shared-ini-file-loader': 2.3.5
+      '@smithy/types': 2.11.0
+      '@smithy/url-parser': 2.1.4
+      '@smithy/util-middleware': 2.1.4
       tslib: 2.5.0
     dev: false
 
@@ -5283,7 +5303,7 @@ packages:
       '@smithy/protocol-http': 3.0.11
       '@smithy/service-error-classification': 2.0.8
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-middleware': 2.0.8
       '@smithy/util-retry': 2.0.8
       tslib: 2.5.0
@@ -5297,7 +5317,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/middleware-serde@2.2.1:
+    resolution:
+      {
+        integrity: sha512-VAWRWqnNjgccebndpyK94om4ZTYzXLQxUmNCXYzM/3O9MTfQjTNBgtFtQwyIIez6z7LWcCsXmnKVIOE9mLqAHQ==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5308,7 +5339,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5321,21 +5352,34 @@ packages:
     dependencies:
       '@smithy/property-provider': 2.0.16
       '@smithy/shared-ini-file-loader': 2.2.7
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
-  /@smithy/node-http-handler@2.2.1:
+  /@smithy/node-config-provider@2.2.5:
     resolution:
       {
-        integrity: sha512-8iAKQrC8+VFHPAT8pg4/j6hlsTQh+NKOWlctJBrYtQa4ExcxX7aSg3vdQ2XLoYwJotFUurg/NLqFCmZaPRrogw==,
+        integrity: sha512-CxPf2CXhjO79IypHJLBATB66Dw6suvr1Yc2ccY39hpR6wdse3pZ3E8RF83SODiNH0Wjmkd0ze4OF8exugEixgA==,
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/abort-controller': 2.0.15
-      '@smithy/protocol-http': 3.0.11
-      '@smithy/querystring-builder': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/property-provider': 2.1.4
+      '@smithy/shared-ini-file-loader': 2.3.5
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/node-http-handler@2.2.2:
+    resolution:
+      {
+        integrity: sha512-XO58TO/Eul/IBQKFKaaBtXJi0ItEQQCT+NI4IiKHCY/4KtqaUT6y/wC1EvDqlA9cP7Dyjdj7FdPs4DyynH3u7g==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/abort-controller': 2.1.4
+      '@smithy/protocol-http': 3.2.2
+      '@smithy/querystring-builder': 2.1.4
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5346,7 +5390,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/property-provider@2.1.4:
+    resolution:
+      {
+        integrity: sha512-nWaY/MImj1BiXZ9WY65h45dcxOx8pl06KYoHxwojDxDL+Q9yLU1YnZpgv8zsHhEftlj9KhePENjQTlNowWVyug==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5357,7 +5412,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/protocol-http@3.2.2:
+    resolution:
+      {
+        integrity: sha512-xYBlllOQcOuLoxzhF2u8kRHhIFGQpDeTQj/dBSnw4kfI29WMKL5RnW1m9YjnJAJ49miuIvrkJR+gW5bCQ+Mchw==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5368,8 +5434,20 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-uri-escape': 2.0.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/querystring-builder@2.1.4:
+    resolution:
+      {
+        integrity: sha512-LXSL0J/nRWvGT+jIj+Fip3j0J1ZmHkUyBFRzg/4SmPNCLeDrtVu7ptKOnTboPsFZu5BxmpYok3kJuQzzRdrhbw==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
+      '@smithy/util-uri-escape': 2.1.1
       tslib: 2.5.0
     dev: false
 
@@ -5380,7 +5458,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/querystring-parser@2.1.4:
+    resolution:
+      {
+        integrity: sha512-U2b8olKXgZAs0eRo7Op11jTNmmcC/sqYmsA7vN6A+jkGnDvJlEl7AetUegbBzU8q3D6WzC5rhR/joIy8tXPzIg==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5391,7 +5480,7 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
     dev: false
 
   /@smithy/shared-ini-file-loader@2.2.7:
@@ -5401,7 +5490,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/shared-ini-file-loader@2.3.5:
+    resolution:
+      {
+        integrity: sha512-oI99+hOvsM8oAJtxAGmoL/YCcGXtbP0fjPseYGaNmJ4X5xOFTer0KPk7AIH3AL6c5AlYErivEi1X/X78HgTVIw==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5414,7 +5514,7 @@ packages:
     dependencies:
       '@smithy/eventstream-codec': 2.0.15
       '@smithy/is-array-buffer': 2.0.0
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-hex-encoding': 2.0.0
       '@smithy/util-middleware': 2.0.8
       '@smithy/util-uri-escape': 2.0.0
@@ -5430,8 +5530,18 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/middleware-stack': 2.0.9
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       '@smithy/util-stream': 2.0.23
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/types@2.11.0:
+    resolution:
+      {
+        integrity: sha512-AR0SXO7FuAskfNhyGfSTThpLRntDI5bOrU0xrpVYU0rZyjl3LBXInZFMTP/NNSd7IS6Ksdtar0QvnrPRIhVrLQ==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
       tslib: 2.5.0
     dev: false
 
@@ -5452,7 +5562,18 @@ packages:
       }
     dependencies:
       '@smithy/querystring-parser': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/url-parser@2.1.4:
+    resolution:
+      {
+        integrity: sha512-1hTy6UYRYqOZlHKH2/2NzdNQ4NNmW2Lp0sYYvztKy+dEQuLvZL9w88zCzFQqqFer3DMcscYOshImxkJTGdV+rg==,
+      }
+    dependencies:
+      '@smithy/querystring-parser': 2.1.4
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5516,7 +5637,7 @@ packages:
     dependencies:
       '@smithy/property-provider': 2.0.16
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       bowser: 2.11.0
       tslib: 2.5.0
     dev: false
@@ -5533,7 +5654,7 @@ packages:
       '@smithy/node-config-provider': 2.1.8
       '@smithy/property-provider': 2.0.16
       '@smithy/smithy-client': 2.1.18
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5545,7 +5666,7 @@ packages:
     engines: { node: '>= 14.0.0' }
     dependencies:
       '@smithy/node-config-provider': 2.1.8
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5566,7 +5687,18 @@ packages:
       }
     engines: { node: '>=14.0.0' }
     dependencies:
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/util-middleware@2.1.4:
+    resolution:
+      {
+        integrity: sha512-5yYNOgCN0DL0OplME0pthoUR/sCfipnROkbTO7m872o0GHCVNJj5xOFJ143rvHNA54+pIPMLum4z2DhPC2pVGA==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5578,7 +5710,7 @@ packages:
     engines: { node: '>= 14.0.0' }
     dependencies:
       '@smithy/service-error-classification': 2.0.8
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -5590,8 +5722,8 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/fetch-http-handler': 2.3.1
-      '@smithy/node-http-handler': 2.2.1
-      '@smithy/types': 2.7.0
+      '@smithy/node-http-handler': 2.2.2
+      '@smithy/types': 2.11.0
       '@smithy/util-base64': 2.0.1
       '@smithy/util-buffer-from': 2.0.0
       '@smithy/util-hex-encoding': 2.0.0
@@ -5603,6 +5735,16 @@ packages:
     resolution:
       {
         integrity: sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==,
+      }
+    engines: { node: '>=14.0.0' }
+    dependencies:
+      tslib: 2.5.0
+    dev: false
+
+  /@smithy/util-uri-escape@2.1.1:
+    resolution:
+      {
+        integrity: sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==,
       }
     engines: { node: '>=14.0.0' }
     dependencies:
@@ -5628,7 +5770,7 @@ packages:
     engines: { node: '>=14.0.0' }
     dependencies:
       '@smithy/abort-controller': 2.0.15
-      '@smithy/types': 2.7.0
+      '@smithy/types': 2.11.0
       tslib: 2.5.0
     dev: false
 
@@ -8661,10 +8803,7 @@ packages:
     dev: true
 
   /esbuild-android-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==,
-      }
+    resolution: { integrity: sha1-IKeuFBbI6q3pF/skU8ElkwLGN6U= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [android]
@@ -8673,10 +8812,7 @@ packages:
     optional: true
 
   /esbuild-android-arm64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==,
-      }
+    resolution: { integrity: sha1-nMDsYFgdatJnVo8pz0iV/92fLwQ= }
     engines: { node: '>=12' }
     cpu: [arm64]
     os: [android]
@@ -8685,10 +8821,7 @@ packages:
     optional: true
 
   /esbuild-darwin-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==,
-      }
+    resolution: { integrity: sha1-Qo4XMOqBnVAICPIg+8UgeuptRBA= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [darwin]
@@ -8697,10 +8830,7 @@ packages:
     optional: true
 
   /esbuild-darwin-arm64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==,
-      }
+    resolution: { integrity: sha1-tt/HeZEVopF/NZcL+8k65QJWszc= }
     engines: { node: '>=12' }
     cpu: [arm64]
     os: [darwin]
@@ -8709,10 +8839,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==,
-      }
+    resolution: { integrity: sha1-ThkNnC0eZxZGGa4wpDi+h9Xu2vI= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [freebsd]
@@ -8721,10 +8848,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-arm64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==,
-      }
+    resolution: { integrity: sha1-GKTANE7iO9Wm0G0Yx24v1tP5FjU= }
     engines: { node: '>=12' }
     cpu: [arm64]
     os: [freebsd]
@@ -8733,10 +8857,7 @@ packages:
     optional: true
 
   /esbuild-linux-32@0.15.18:
-    resolution:
-      {
-        integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==,
-      }
+    resolution: { integrity: sha1-mjKXMe4HmxImK3k/uE7qdi6C4M4= }
     engines: { node: '>=12' }
     cpu: [ia32]
     os: [linux]
@@ -8745,10 +8866,7 @@ packages:
     optional: true
 
   /esbuild-linux-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==,
-      }
+    resolution: { integrity: sha1-Uyc4B1OXuZRGe1FOUkrrUgwZG2w= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [linux]
@@ -8757,10 +8875,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==,
-      }
+    resolution: { integrity: sha1-U3LnmTrC2o8GsroxNxDXIreobl0= }
     engines: { node: '>=12' }
     cpu: [arm64]
     os: [linux]
@@ -8769,10 +8884,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm@0.15.18:
-    resolution:
-      {
-        integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==,
-      }
+    resolution: { integrity: sha1-5zSq8lmi49EJ1IhsnoHsDy/Zqcw= }
     engines: { node: '>=12' }
     cpu: [arm]
     os: [linux]
@@ -8781,10 +8893,7 @@ packages:
     optional: true
 
   /esbuild-linux-mips64le@0.15.18:
-    resolution:
-      {
-        integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==,
-      }
+    resolution: { integrity: sha1-wEh8FKk3GoTrCPqw4dewRadxBes= }
     engines: { node: '>=12' }
     cpu: [mips64el]
     os: [linux]
@@ -8793,10 +8902,7 @@ packages:
     optional: true
 
   /esbuild-linux-ppc64le@0.15.18:
-    resolution:
-      {
-        integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==,
-      }
+    resolution: { integrity: sha1-rwSK2U7tDOMvbVqHP3q+kRUBJQc= }
     engines: { node: '>=12' }
     cpu: [ppc64]
     os: [linux]
@@ -8805,10 +8911,7 @@ packages:
     optional: true
 
   /esbuild-linux-riscv64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==,
-      }
+    resolution: { integrity: sha1-Qj7U5ZJ713+EK9VmlyF49CTUVeY= }
     engines: { node: '>=12' }
     cpu: [riscv64]
     os: [linux]
@@ -8817,10 +8920,7 @@ packages:
     optional: true
 
   /esbuild-linux-s390x@0.15.18:
-    resolution:
-      {
-        integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==,
-      }
+    resolution: { integrity: sha1-IdIeqpYqGDv7djEuWgHMWuSM6Os= }
     engines: { node: '>=12' }
     cpu: [s390x]
     os: [linux]
@@ -8829,10 +8929,7 @@ packages:
     optional: true
 
   /esbuild-netbsd-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==,
-      }
+    resolution: { integrity: sha1-rnVoL2DQhWCx/pSCv+AXPlEQuZg= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [netbsd]
@@ -8841,10 +8938,7 @@ packages:
     optional: true
 
   /esbuild-openbsd-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==,
-      }
+    resolution: { integrity: sha1-eVkakKo7A+SGP5O+7A0rqyhT0Kg= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [openbsd]
@@ -8853,10 +8947,7 @@ packages:
     optional: true
 
   /esbuild-sunos-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==,
-      }
+    resolution: { integrity: sha1-/VKKpdpTdLfh6T0275sHw9/tKXE= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [sunos]
@@ -8865,10 +8956,7 @@ packages:
     optional: true
 
   /esbuild-windows-32@0.15.18:
-    resolution:
-      {
-        integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==,
-      }
+    resolution: { integrity: sha1-DpK2bs31Q1p2gTxLxczaBpb078M= }
     engines: { node: '>=12' }
     cpu: [ia32]
     os: [win32]
@@ -8877,10 +8965,7 @@ packages:
     optional: true
 
   /esbuild-windows-64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==,
-      }
+    resolution: { integrity: sha1-D8dh14VBQoT8QI55FCJtM/gkINA= }
     engines: { node: '>=12' }
     cpu: [x64]
     os: [win32]
@@ -8889,10 +8974,7 @@ packages:
     optional: true
 
   /esbuild-windows-arm64@0.15.18:
-    resolution:
-      {
-        integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==,
-      }
+    resolution: { integrity: sha1-W1vcVtNB0JIu6UllyJ7hIKaobrc= }
     engines: { node: '>=12' }
     cpu: [arm64]
     os: [win32]
@@ -8994,7 +9076,6 @@ packages:
         integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
       }
     engines: { node: '>=10' }
-    dev: true
 
   /escodegen@2.0.0:
     resolution:
@@ -10471,6 +10552,11 @@ packages:
     dependencies:
       lru-cache: 10.0.1
     dev: true
+
+  /hpagent@1.2.0:
+    resolution: { integrity: sha1-CuQXiVQw6zdwwDRDRWuNkMpGSQM= }
+    engines: { node: '>=14' }
+    dev: false
 
   /html-encoding-sniffer@3.0.0:
     resolution:
@@ -12326,6 +12412,13 @@ packages:
       }
     engines: { node: '>=8' }
     dev: true
+
+  /matcher@4.0.0:
+    resolution: { integrity: sha1-pCoFoJqu2S4tJB65H92saJRh6lE= }
+    engines: { node: '>=10' }
+    dependencies:
+      escape-string-regexp: 4.0.0
+    dev: false
 
   /meow@12.1.1:
     resolution:


### PR DESCRIPTION
I took a stab at #176 since our project needed to access s3 from behind a corporate proxy.  It's working well for us, but the one thing I haven't been able to test is running this outside of a proxy.  Please take a look and let me know if you'd like any changes.