### PR TITLE
fix(nx-remotecache-s3): remove readOnly param and env var

### DIFF
--- a/libs/nx-remotecache-s3/README.md
+++ b/libs/nx-remotecache-s3/README.md
@@ -20,7 +20,6 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
 | Region           | Optional. The AWS region to which this client will send requests.                                                                                     | `NXCACHE_S3_REGION`              | `region`         |
 | Profile          | Optional. The AWS profile to use to authenticate.                                                                                                     | `NXCACHE_S3_PROFILE`             | `profile`        |
 | Force Path Style | Optional. Whether to force path style URLs for S3 objects (e.g., `https://s3.amazonaws.com/<bucket>/` instead of `https://<bucket>.s3.amazonaws.com/` | `NXCACHE_S3_FORCE_PATH_STYLE`    | `forcePathStyle` |
-| Read Only        | Optional. Disable writing cache to the S3 bucket. This may be useful if you only want to write to the cache from a CI but not localhost.              | `NXCACHE_S3_READ_ONLY`           | `readOnly`       |
 | Http Proxy       | Optional. Useful when your environment must connect to a proxy to access the internet.                                                                | `http_proxy` \|\| `HTTP_PROXY`   |                  |
 | Https Proxy      | Optional. Useful when your environment must connect to a proxy to access the internet.                                                                | `https_proxy` \|\| `HTTPS_PROXY` |                  |
 | No Proxy         | Optional. Useful when your environment must connect to a proxy to access the internet, but is not needed for connecting to aws.                       | `no_proxy` \|\| `NO_PROXY`       |                  |
@@ -37,8 +36,7 @@ npm install --save-dev @pellegrims/nx-remotecache-s3
         "prefix": "prefix/",
         "region": "us-west-000",
         "profile": "name-of-aws-profile",
-        "forcePathStyle": true,
-        "readOnly": false
+        "forcePathStyle": true
       }
     }
   }
@@ -71,7 +69,7 @@ Hash: d3d2bea71ea0f3004304c5cc88cf91be50b02bb636ebbdfcc927626fd8edf1ae
 
 ## Advanced Configuration
 
-See [nx-remotecache-custom](https://github.com/NiklasPor/nx-remotecache-custom#advanced-configuration).
+See [nx-remotecache-custom](https://github.com/NiklasPor/nx-remotecache-custom#advanced-configuration) for more options like the ability to disable writes which may be useful if you only want to write to the cache from a CI but not localhost.
 
 ### Proxy Configuration
 

--- a/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.spec.ts
@@ -235,20 +235,6 @@ describe('setupS3TaskRunner', () => {
           });
         });
       });
-      describe('should not call Upload when readonly', () => {
-        it('through option', async () => {
-          const runner = await setupS3TaskRunner({
-            ...defaultOptions,
-            readOnly: true,
-          });
-          expect(runner.storeFile).toThrowError('ReadOnly');
-        });
-        it('through env variable', async () => {
-          process.env.NXCACHE_S3_READ_ONLY = 'true';
-          const runner = await setupS3TaskRunner(emptyOptions);
-          expect(runner.storeFile).toThrowError('ReadOnly');
-        });
-      });
     });
   });
 });

--- a/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.ts
+++ b/libs/nx-remotecache-s3/src/lib/setup-s3-task-runner.ts
@@ -1,14 +1,13 @@
 import { Upload } from '@aws-sdk/lib-storage';
 import { initEnv } from 'nx-remotecache-custom';
 import { buildS3Client } from './s3-client';
-import { buildCommonCommandInput, getEnv, isReadOnly } from './util';
+import { buildCommonCommandInput, getEnv } from './util';
 
 import type { CustomRunnerOptions } from 'nx-remotecache-custom';
 import type { RemoteCacheImplementation } from 'nx-remotecache-custom/types/remote-cache-implementation';
 
 const ENV_BUCKET = 'NXCACHE_S3_BUCKET';
 const ENV_PREFIX = 'NXCACHE_S3_PREFIX';
-const ENV_READ_ONLY = 'NXCACHE_S3_READ_ONLY';
 
 export interface S3Options {
   bucket?: string;
@@ -16,7 +15,6 @@ export interface S3Options {
   forcePathStyle?: boolean;
   prefix?: string;
   profile?: string;
-  readOnly?: boolean;
   region?: string;
 }
 
@@ -29,7 +27,6 @@ export const setupS3TaskRunner = async (
 
   const bucket = getEnv(ENV_BUCKET) ?? options.bucket;
   const prefix = getEnv(ENV_PREFIX) ?? options.prefix ?? '';
-  const readOnly = isReadOnly(options, ENV_READ_ONLY);
 
   return {
     name: 'S3',
@@ -57,10 +54,6 @@ export const setupS3TaskRunner = async (
       return result.Body as NodeJS.ReadableStream;
     },
     storeFile: (filename: string, stream) => {
-      if (readOnly) {
-        throw new Error('ReadOnly');
-      }
-
       const upload = new Upload({
         client: s3Storage,
         params: {

--- a/libs/nx-remotecache-s3/src/lib/test-utils.ts
+++ b/libs/nx-remotecache-s3/src/lib/test-utils.ts
@@ -11,7 +11,6 @@ export const defaultOptions: CustomRunnerOptions<S3Options> = {
   profile: 'optionsProfile',
   bucket: 'optionsBucket',
   prefix: 'optionsPrefix',
-  readOnly: false,
 };
 
 export const envValues: Record<keyof S3Options, string> = {
@@ -21,7 +20,6 @@ export const envValues: Record<keyof S3Options, string> = {
   profile: 'envProfile',
   bucket: 'envBucket',
   prefix: 'envPrefix',
-  readOnly: 'false',
 };
 
 export const clearProxyInfo = () => {

--- a/libs/nx-remotecache-s3/src/lib/util.spec.ts
+++ b/libs/nx-remotecache-s3/src/lib/util.spec.ts
@@ -1,8 +1,7 @@
-import { clearProxyInfo, emptyOptions } from './test-utils';
+import { clearProxyInfo } from './test-utils';
 import {
   buildCommonCommandInput,
   getEnv,
-  isReadOnly,
   getHttpProxy,
   getHttpsProxy,
 } from './util';
@@ -48,42 +47,6 @@ describe('util', () => {
         Key: 'prefixfilename',
         /* eslint-enable @typescript-eslint/naming-convention */
       });
-    });
-  });
-  describe('isReadOnly', () => {
-    it('returns true when option is true and env is undefined', () => {
-      expect(isReadOnly({ ...emptyOptions, readOnly: true }, 'TEST_ENV')).toBe(
-        true
-      );
-    });
-    it('returns false when option is false and env is undefined', () => {
-      expect(isReadOnly({ ...emptyOptions, readOnly: false }, 'TEST_ENV')).toBe(
-        false
-      );
-    });
-    it('returns true when env is true', () => {
-      process.env.TEST_ENV = 'true';
-      expect(isReadOnly({ ...emptyOptions }, 'TEST_ENV')).toBe(true);
-    });
-    it('returns false when env is false', () => {
-      process.env.TEST_ENV = 'false';
-      expect(isReadOnly({ ...emptyOptions }, 'TEST_ENV')).toBe(false);
-    });
-    it('returns true when env is "somestring" and option is true', () => {
-      process.env.TEST_ENV = 'somestring';
-      expect(isReadOnly({ ...emptyOptions, readOnly: true }, 'TEST_ENV')).toBe(
-        true
-      );
-    });
-    it('returns false when env is "somestring" and option is false', () => {
-      process.env.TEST_ENV = 'somestring';
-      expect(isReadOnly({ ...emptyOptions, readOnly: false }, 'TEST_ENV')).toBe(
-        false
-      );
-    });
-    it('returns false when env is "somestring" and option is undefined', () => {
-      process.env.TEST_ENV = 'somestring';
-      expect(isReadOnly({ ...emptyOptions }, 'TEST_ENV')).toBe(false);
     });
   });
   describe('get proxy information', () => {

--- a/libs/nx-remotecache-s3/src/lib/util.ts
+++ b/libs/nx-remotecache-s3/src/lib/util.ts
@@ -1,5 +1,3 @@
-import type { CustomRunnerOptions } from 'nx-remotecache-custom';
-import type { S3Options } from './setup-s3-task-runner';
 import { isMatch } from 'matcher';
 
 const HTTP_PROXY = 'HTTP_PROXY';
@@ -18,18 +16,6 @@ export const buildCommonCommandInput = (
   Key: `${prefix}${filename}`,
   /* eslint-enable @typescript-eslint/naming-convention */
 });
-
-export const isReadOnly = (
-  options: CustomRunnerOptions<S3Options>,
-  envReadOnly: string
-) => {
-  const readonly = getEnv(envReadOnly);
-  if (typeof readonly !== 'undefined') {
-    if (readonly === 'true') return true;
-    if (readonly === 'false') return false;
-  }
-  return options.readOnly ?? false;
-};
 
 export const getHttpProxy = (): string | undefined =>
   getEnv(HTTP_PROXY.toLowerCase()) || getEnv(HTTP_PROXY) || undefined;


### PR DESCRIPTION
**Problem**
Currently when using the readOnly param, a noisy error message is thrown even though the behavior is correct and what's expected:
```
------------------------------------------------------------------------------
Warning: Failed to store cache to S3
File: 17266409248928305490.tar.gz
Error: ReadOnly
------------------------------------------------------------------------------
```

**Solution**
It looks like perhaps this Param was written before the underlying package included read and write parameters. This PR removes all the behavior in the S3 package, instead relying on the behavior in the custom package upstream which prevents calling `storeFile` in the first place

BREAKING CHANGE: Update to use `write: false` or `NXCACHE_WRITE=false` from `nx-remotecache-custom`